### PR TITLE
fix mixed content

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
       </nav>
       <p id="copyright">&copy; 2011 - {{ site.time | date: '%Y' }} {{ site.title }}</p>
     </footer>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <script type="text/javascript">
       jQuery(function($) {
         $('nav li').each(function() {


### PR DESCRIPTION
## 概要
- https://ruby-no-kai.org/ ページにおいて、 jQuery 読み込みがブロックされていたため修正しました。

## 変更内容
- Mixed Content を解消するため、 jQuery の読み込み先を `https` に変更しました。
  - Google Hosted Libraries で 同バージョンの `https` 版があったため利用しています。
    - https://developers.google.com/speed/libraries#jquery

## 確認環境
- Google Chrome 78.0.3904.70
- FireFox 70.0

## 備考
- ナビバーの現在ページをハイライトする処理が動作するようになります。
  - Before
    ![スクリーンショット 2019-10-29 12 49 31](https://user-images.githubusercontent.com/10830974/67736349-a38d9680-fa4a-11e9-97b3-e8c50baa8203.png)
  - After
    ![スクリーンショット 2019-10-29 12 50 02](https://user-images.githubusercontent.com/10830974/67736348-a38d9680-fa4a-11e9-9253-f1eff692be2e.png)
