### PR TITLE
公式Wikiをscrapboxに移行

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
           <li><a href="/bylaws.html">日本Rubyの会定款</a></li>
           <li><a href="/code-of-conduct.html">行動規範</a></li>
           <li><a href="/mailinglist.html">入会案内</a></li>
-          <li><a href="https://github.com/ruby-no-kai/official/wiki">公式Wiki</a></li>
+          <li><a href="https://scrapbox.io/ruby-no-kai/">公式Wiki</a></li>
           <li><a href="/contact.html">お問い合わせ</a></li>
         </ul>
       </nav>

--- a/index.md
+++ b/index.md
@@ -24,4 +24,4 @@ layout: default
 
 日本Rubyの会についての詳細については[日本Rubyの会について](/aboutus.html)を参照してください。
 
-日本Rubyの会についての最新情報については[公式Wiki](https://github.com/ruby-no-kai/official/wiki)を参照してください。
+日本Rubyの会についての最新情報については[公式Wiki](https://scrapbox.io/ruby-no-kai/)を参照してください。


### PR DESCRIPTION
GitHub Wikiではあまりいきいきとしたメンテナンスができなかったため。

[公式Wikiの選定基準](https://scrapbox.io/ruby-no-kai/%E5%85%AC%E5%BC%8FWiki%E7%9A%84%E3%81%AA%E3%83%84%E3%83%BC%E3%83%AB%E3%81%AE%E9%81%B8%E5%AE%9A%E5%9F%BA%E6%BA%96)

※ このPRをマージ後、https://github.com/ruby-no-kai/official/wiki は閉じること